### PR TITLE
- don't check final_pos against MAX/MIN_X_WINDOW_POSITION

### DIFF
--- a/fvwm/move_resize.c
+++ b/fvwm/move_resize.c
@@ -664,14 +664,6 @@ static int GetOnePositionArgument(
 		fvwm_debug(
 			__func__, "new position is out of range: %d",
 			final_pos);
-		if (final_pos > MAX_X_WINDOW_POSITION)
-		{
-			final_pos = MAX_X_WINDOW_POSITION;
-		}
-		else if (final_pos < MIN_X_WINDOW_POSITION)
-		{
-			final_pos = MIN_X_WINDOW_POSITION;
-		}
 	}
 	*pFinalPos = final_pos;
 
@@ -4426,7 +4418,7 @@ static Bool _resize_window(F_CMD_ARGS)
 			FQueryPointer(
 				    dpy, Scr.Root, &JunkRoot, &JunkChild, &x,
 				    &y, &JunkX, &JunkY, &JunkMask);
-			
+
 			fev_make_null_event(&e2, dpy);
 			e2.type = MotionNotify;
 			e2.xmotion.time = fev_get_evtime();


### PR DESCRIPTION
- allows creating windows on virtual positions outside of those limits
- seems to run fine, or my use of fvwm3 doesn't ever hit a problem with this

* **What does this PR do?**

* **Screenshots (if applicable)**

* **PR acceptance criteria** (reminder only, please delete once read)

  - Your commit message(s) are descriptive.  See:

    https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

  - [https://raw.githubusercontent.com/fvwmorg/fvwm3/main/doc/README]Documentation updated (where appropriate)

  - Style guide followed (try and match the surrounding code where possible)

  - All tests are passing:  although this is automatic, Codacy will often
    highlight additional considerations which will need to be addressed before
    the PR can be merged.

* **Issue number(s)**

If this PR addresses any issues, please ensure the appropriate commit
message(s) contains:

```
Fixes #XXX
```

at the end of your commit message, where `XXX` should be replaced with the
relevant issue number.

If there is more than one issue fixed then use:

```
Fixes #XXX, fixes #YYY, fixes #ZZZ
```